### PR TITLE
Added absolute positioning to select field labels

### DIFF
--- a/sass/components/form/components/_select.scss
+++ b/sass/components/form/components/_select.scss
@@ -26,14 +26,15 @@ $component-form-select-properties: $default-component-form-select-properties !de
     position: relative;
     label{
       display: block;
-      transform: translate(20px, 45px);
+      position: absolute;
+      transform: translate(20px, 25px);
       transform-origin: left;
       transition: transform .25s ease;
       color: getThemeProperty(shiftingLabelColor, $component-form-select-properties);
       pointer-events: none;
       margin: 0;
       &.labelShrunk{
-        transform: scale(.7) translate(30px, 40px);
+        transform: scale(.7) translate(30px, 20px);
       }
     }
     select{


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/#/tasks/28013615

### Summary
Added absolute positioning to select field labels

### Testing Steps
- [x] test with werkbot site
- [x] run grunt and compile sass
- [x] /make-a-payment
- [x] get to Payment Information step
- [x] confirm state dropdown is aligned with zip code text field
