### PR TITLE
Added z-indexes to form labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "werkbot-framewerk",
-  "version": "2.0.01",
+  "version": "2.0.02",
   "description": "A framework of css and javascript that Werkbot uses as a foundation to build our websites.",
   "main": "js/form.js",
   "directories": {

--- a/sass/components/form/components/_select.scss
+++ b/sass/components/form/components/_select.scss
@@ -33,6 +33,7 @@ $component-form-select-properties: $default-component-form-select-properties !de
       color: getThemeProperty(shiftingLabelColor, $component-form-select-properties);
       pointer-events: none;
       margin: 0;
+      z-index: 1;
       &.labelShrunk{
         transform: scale(.7) translate(30px, 20px);
       }

--- a/sass/components/form/components/_text.scss
+++ b/sass/components/form/components/_text.scss
@@ -28,6 +28,7 @@ $component-form-text-properties: $default-component-form-text-properties !defaul
       color: getThemeProperty(shiftingLabelColor, $component-form-text-properties);
       pointer-events: none;
       margin: 0;
+      z-index: 1;
       &.labelShrunk{
         transform: scale(.7) translate(30px, 20px);
       }

--- a/sass/components/form/components/_textarea.scss
+++ b/sass/components/form/components/_textarea.scss
@@ -28,6 +28,7 @@ $component-form-textarea-properties: $default-component-form-textarea-properties
       color: getThemeProperty(shiftingLabelColor, $component-form-textarea-properties);
       pointer-events: none;
       margin: 0;
+      z-index: 1;
       &.labelShrunk{
         transform: scale(.7) translate(30px, 20px);
       }


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/#/tasks/28119173

### Summary
Added z-indexes to form labels. `div`s in form groups can get `position: relative`, which will cause the input container to overlap the label.