### PR TITLE
Checkbox input width fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "werkbot-framewerk",
-  "version": "2.0.02",
+  "version": "2.0.03",
   "description": "A framework of css and javascript that Werkbot uses as a foundation to build our websites.",
   "main": "js/form.js",
   "directories": {

--- a/sass/components/form/components/_checkbox.scss
+++ b/sass/components/form/components/_checkbox.scss
@@ -21,6 +21,7 @@ $component-form-checkbox-properties: $default-component-form-checkbox-properties
     input{
       -moz-appearance: initial; // Enables pseudo elements in FireFox
       min-width: 13px; // Does not inherit width in Firefox. Used for spacing
+      width: initial;
       border: none;
       &::before{
         font-family: getThemeProperty(iconFontFamily, $component-form-checkbox-properties);


### PR DESCRIPTION
### Summary
Added default width to checkbox, that way it does not get `width: 100%`

### Testing Steps
- [x] test with werkbot site update https://github.com/werkbot/werkbot/pull/59

### Concern
- This is only a style rule specific enough to take priority over the shopping cart form style.
