### PR TITLE
Updated link tag <a> to have properties that can be overridden

### DIFF
--- a/docs/en/components.md
+++ b/docs/en/components.md
@@ -6,11 +6,10 @@ These are the tags defined within the framework.
 - `<hr>`
 - `<html>`
 - `<image>`
-- `<link>`
-- `<list>`
+- `<a>` [Learn more about the a tag](taga.md)
+- `<ul><ol>`
 - `<table>`
-- `typography` consists of tags focused around typography
-* [Learn more about typography](typography.md)
+- `typography` consists of tags focused around typography, [Learn more about typography](typography.md)
 
 ## Components
 These are the components we have defined within the framework.

--- a/docs/en/taga.md
+++ b/docs/en/taga.md
@@ -1,0 +1,36 @@
+# `<a>` Tag
+
+```
+// Default link Properties
+$default-element-link-properties:(
+  linkColor: getThemeProperty(textColorDark),
+  linkColorVisited:getThemeProperty(textColorDark),
+  linkColorActive: getThemeProperty(textColorDark),
+  linkColorHover: getThemeProperty(textColorDark),
+  linkDecoration: underline,
+  linkDecorationHover: none
+);
+```
+
+## Mixin
+A mixin is provided to override the default link properties.
+```
+@mixin fw-mixin-link($properties) {
+    ...
+```
+
+For example, consider a section where all the links need to be white text instead of the default dark text color:
+```
+.dark-section a{
+      $properties:(
+        linkColor: getThemeProperty(textColorLight),
+        linkColorVisited:getThemeProperty(textColorLight),
+        linkColorActive: getThemeProperty(textColorLight),
+        linkColorHover: getThemeProperty(textColorLight),
+        linkDecoration: none,
+        linkDecorationHover: none
+      );
+      @include fw-mixin-link($properties);
+}
+```
+All links in this section would then be updated.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,23 @@
 {
   "name": "werkbot-framewerk",
-  "version": "2.0.04",
-  "lockfileVersion": 1,
+  "version": "2.0.6",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "werkbot-framewerk",
+      "version": "2.0.6",
+      "license": "MIT",
+      "dependencies": {
+        "hamburgers": "~1.1.3"
+      }
+    },
+    "node_modules/hamburgers": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/hamburgers/-/hamburgers-1.1.3.tgz",
+      "integrity": "sha512-qpfnJwZq6ATAGJEriwuyfVNgT++GG+o+3bBfPYF7F3WY452cYKbaYGUuqwhp+3kHLI6CL4VIBfj8bfbp90Lp1A=="
+    }
+  },
   "dependencies": {
     "hamburgers": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "werkbot-framewerk",
-  "version": "2.0.05",
+  "version": "2.0.6",
   "description": "A framework of css and javascript that Werkbot uses as a foundation to build our websites.",
   "main": "js/form.js",
   "directories": {

--- a/sass/elements/link/_link.scss
+++ b/sass/elements/link/_link.scss
@@ -1,21 +1,43 @@
-/*
-  Link
-  Default link styles
-*/
-a{
-  color: getThemeProperty(primaryColor);
-  text-decoration: underline;
+// Default link Properties
+$default-element-link-properties:(
+  linkColor: getThemeProperty(textColorDark),
+  linkColorVisited:getThemeProperty(textColorDark),
+  linkColorActive: getThemeProperty(textColorDark),
+  linkColorHover: getThemeProperty(textColorDark),
+  linkDecoration: underline,
+  linkDecorationHover: none
+);
+// If $element-link-properties is set, lets merge into our defaults
+$element-link-properties: $default-element-link-properties !default;
+@if($element-link-properties){
+  $element-link-properties: map-merge($default-element-link-properties, $element-link-properties);
+}
+
+// Mixin for applying to an a element, this exists for when you want a whole section to have a different
+// property (color, etc...) for a certain section where the default properties do not work.
+@mixin fw-mixin-link($properties) {
+  @if($properties){
+    $properties: map-merge($default-element-link-properties, $properties);
+  }
+  color: getThemeProperty(linkColor, $properties);
+  text-decoration: getThemeProperty(linkDecoration, $properties);
   &:link{
-    color: getThemeProperty(primaryColor);
+    color: getThemeProperty(linkColor, $properties);
   }
   &:visited{
-    color: darken(getThemeProperty(primaryColor), 10);
+    color: getThemeProperty(linkColorVisited, $properties);
   }
   &:hover{
-    text-decoration: none;
+    color: getThemeProperty(linkColorHover, $properties);
+    text-decoration: getThemeProperty(linkDecorationHover, $properties);
   }
   &:active{
-    color: lighten(getThemeProperty(primaryColor), 10);
+    color: getThemeProperty(linkColorActive, $properties);
   }
   @include focus-style;
+}
+
+// Apply the mixin to the default a element
+a{
+  @include fw-mixin-link($element-link-properties);
 }


### PR DESCRIPTION
### Summary
> Updated the <a> tag to have properties that can be overridden

### Testing Steps
- [ ] Use a site that uses the updated framewerk
- [ ] Build the site with this branch
- [ ] Attempt to override the default link properties, run your grunt build
- [ ] Confirm the links are showing correctly

### Issues/Concerns
- Refer to the docs on how to update the link properties (Apart of this PR)
