### PR TITLE
Added release drafter and package version updater

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,31 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## What’s Changed
+
+  $CHANGES

--- a/.github/workflows/draftrelease.yml
+++ b/.github/workflows/draftrelease.yml
@@ -1,0 +1,47 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    outputs:
+      output: ${{ steps.update_release_draft.outputs.tag_name }}
+    steps:
+      - name: Draft Release
+        id: update_release_draft
+        uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@master
+
+      # Get the current package.json version number
+      - name: Compare Versions
+        id: compare_versions
+        run: |
+          CURRENTVERSION=$(npm version | grep werkbot-framewerk | sed -re "s/[a-z]*//g;s/[-|,|:|']//g;s/\s//g")
+          echo "::set-output name=current_version_number::$CURRENTVERSION"
+        
+      # Update the package.json version number.
+      # This only runs when the draft release tag_name differs from the current package.json version number.
+      - name: Update package.json version
+        if: steps.update_release_draft.outputs.tag_name != steps.compare_versions.outputs.current_version_number
+        uses: reedyuk/npm-version@1.1.1
+        with:
+          version: ${{ steps.update_release_draft.outputs.tag_name }}
+
+      - name: Commit Updated package.json
+        if: steps.update_release_draft.outputs.tag_name != steps.compare_versions.outputs.current_version_number
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Updated package.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "werkbot-framewerk",
-  "version": "2.0.06",
+  "version": "2.0.6",
   "description": "A framework of css and javascript that Werkbot uses as a foundation to build our websites.",
   "main": "js/form.js",
   "directories": {


### PR DESCRIPTION
### Summary
https://werkbotstudios.teamwork.com/#/tasks/29294301

### Testing Steps
- [x] fork this repo
- [ ] delete the npm publish action in your fork
- [ ] (optional) create a new default branch on your fork to work off of, just be sure to [update the workflow files to refer to that branch](https://github.com/werkbot/framewerk/pull/33/files#diff-0b43b87e8545653ec0f6938078d202f78ed70e2bd4bd8c4e0ae410a41dc252a0R6)
- [x] create PRs with labels and merge them into your default branch
- [x] confirm the package.json version number was automatically updated
- [x] confirm the draft release is generated correctly
- [x] with an existing **draft** release, commit to the default branch again
- [x] confirm the package.json version number does not change since we are still waiting on the release to be published
- [x] do another PR, and use a "minor" or "major" label, merge this
- [x] confirm the draft release was updated, as well as the package.json version

### Issues/Concerns
- This does not include a changelog generator. That was added to SilverStripe modules to meet compliance, but it could be added here too.
- For the npm version patch to work, there can be no leading zeros in the patch number, so I removed the one here.
