### PR TITLE
Dart sass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,28 +1,13 @@
 {
   "name": "werkbot-framewerk",
   "version": "2.0.8",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "werkbot-framewerk",
-      "version": "2.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "hamburgers": "~1.1.3"
-      }
-    },
-    "node_modules/hamburgers": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/hamburgers/-/hamburgers-1.1.3.tgz",
-      "integrity": "sha512-qpfnJwZq6ATAGJEriwuyfVNgT++GG+o+3bBfPYF7F3WY452cYKbaYGUuqwhp+3kHLI6CL4VIBfj8bfbp90Lp1A=="
-    }
-  },
   "dependencies": {
     "hamburgers": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/hamburgers/-/hamburgers-1.1.3.tgz",
-      "integrity": "sha512-qpfnJwZq6ATAGJEriwuyfVNgT++GG+o+3bBfPYF7F3WY452cYKbaYGUuqwhp+3kHLI6CL4VIBfj8bfbp90Lp1A=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/hamburgers/-/hamburgers-1.2.1.tgz",
+      "integrity": "sha512-uFuVVF7/MeUtRWrA+S1FGGo4iVi7RgPzZAmljBnSeDh4snOZzaQ+oB6CI1m4vKD5RGz9s70ufgiJLxgivqA26Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/werkbot/framewerk#readme",
   "dependencies": {
-    "hamburgers": "^1.2"
+    "hamburgers": "^1.2",
+    "@fortawesome/fontawesome-pro": "^6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   },
   "homepage": "https://github.com/werkbot/framewerk#readme",
   "dependencies": {
-    "hamburgers": "~1.1.3"
+    "hamburgers": "^1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   },
   "homepage": "https://github.com/werkbot/framewerk#readme",
   "dependencies": {
-    "hamburgers": "^1.1"
+    "hamburgers": "^1.2"
   }
 }

--- a/sass/base/layout/_layout.scss
+++ b/sass/base/layout/_layout.scss
@@ -8,7 +8,7 @@
 }
 @for $i from 1 through 100 {
   .desktop-#{$i} {
-    width: round(percentage($i / 100));
+    width: round(percentage(calc($i / 100)));
   }
 }
 .desktop-hide{
@@ -32,7 +32,7 @@
     }
     @for $i from 1 through 100 {
       .#{$label}-#{$i} {
-        width: round(percentage($i / 100));
+        width: round(percentage(calc($i / 100)));
       }
     }
     .#{$label}-auto{
@@ -58,7 +58,7 @@
     }
     @for $i from 1 through 100 {
       .#{$label}-#{$i} {
-        width: round(percentage($i / 100));
+        width: round(percentage(calc($i / 100)));
       }
     }
     .#{$label}-auto{

--- a/sass/base/layout/_layout.scss
+++ b/sass/base/layout/_layout.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 /*
   DEFAULT DESKTOP
   If no breakpoints are defined, these will be the fallback width percentages
@@ -8,7 +10,7 @@
 }
 @for $i from 1 through 100 {
   .desktop-#{$i} {
-    width: round(percentage(calc($i / 100)));
+    width: round(percentage(math.div($i, 100)));
   }
 }
 .desktop-hide{
@@ -32,7 +34,7 @@
     }
     @for $i from 1 through 100 {
       .#{$label}-#{$i} {
-        width: round(percentage(calc($i / 100)));
+        width: round(percentage(math.div($i, 100)));
       }
     }
     .#{$label}-auto{
@@ -58,7 +60,7 @@
     }
     @for $i from 1 through 100 {
       .#{$label}-#{$i} {
-        width: round(percentage(calc($i / 100)));
+        width: round(percentage(math.div($i, 100)));
       }
     }
     .#{$label}-auto{

--- a/sass/base/space/_space.scss
+++ b/sass/base/space/_space.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 /*
   Space
   getThemeProperty(layoutSpace) variable is defined in _fw-variables.scss
@@ -16,7 +18,7 @@
     padding: getThemeProperty(layoutSpace) * 0.25;
   }
   &.half{
-    padding: calc(getThemeProperty(layoutSpace) / 2);
+    padding: math.div(getThemeProperty(layoutSpace), 2);
   }
   &.three-forths{
     padding: getThemeProperty(layoutSpace) * 0.75;
@@ -28,10 +30,10 @@
 		padding-right: 0;
 	}
 	&.halfleft{
-		padding-left: calc(getThemeProperty(layoutSpace) / 2);
+		padding-left: math.div(getThemeProperty(layoutSpace), 2);
 	}
 	&.halfright{
-		padding-right: calc(getThemeProperty(layoutSpace) / 2);
+		padding-right: math.div(getThemeProperty(layoutSpace), 2);
 	}
 	&.notop{
 		padding-top: 0;
@@ -40,9 +42,9 @@
 		padding-bottom: 0;
 	}
 	&.halftop{
-		padding-top: calc(getThemeProperty(layoutSpace) / 2);
+		padding-top: math.div(getThemeProperty(layoutSpace), 2);
 	}
 	&.halfbottom{
-		padding-bottom: calc(getThemeProperty(layoutSpace) / 2);
+		padding-bottom: math.div(getThemeProperty(layoutSpace), 2);
 	}
 }

--- a/sass/base/space/_space.scss
+++ b/sass/base/space/_space.scss
@@ -16,7 +16,7 @@
     padding: getThemeProperty(layoutSpace) * 0.25;
   }
   &.half{
-    padding: getThemeProperty(layoutSpace) / 2;
+    padding: calc(getThemeProperty(layoutSpace) / 2);
   }
   &.three-forths{
     padding: getThemeProperty(layoutSpace) * 0.75;
@@ -28,10 +28,10 @@
 		padding-right: 0;
 	}
 	&.halfleft{
-		padding-left: getThemeProperty(layoutSpace) / 2;
+		padding-left: calc(getThemeProperty(layoutSpace) / 2);
 	}
 	&.halfright{
-		padding-right: getThemeProperty(layoutSpace) / 2;
+		padding-right: calc(getThemeProperty(layoutSpace) / 2);
 	}
 	&.notop{
 		padding-top: 0;
@@ -40,9 +40,9 @@
 		padding-bottom: 0;
 	}
 	&.halftop{
-		padding-top: getThemeProperty(layoutSpace) / 2;
+		padding-top: calc(getThemeProperty(layoutSpace) / 2);
 	}
 	&.halfbottom{
-		padding-bottom: getThemeProperty(layoutSpace) / 2;
+		padding-bottom: calc(getThemeProperty(layoutSpace) / 2);
 	}
 }

--- a/sass/elements/typography/_typography.scss
+++ b/sass/elements/typography/_typography.scss
@@ -1,7 +1,7 @@
 // Default form checkbox Properties
 $default-component-typography-properties:(
     "HeadingColor": getThemeProperty(textColorDark),
-    "HeadingMargin": 0 0 getThemeProperty(layoutSpace)/2 0
+    "HeadingMargin": 0 0 calc(getThemeProperty(layoutSpace) / 2) 0
 );
 // If $component-form-checkbox-properties is set, lets merge into our defaults
 $component-typography-properties: $default-component-typography-properties !default;

--- a/sass/elements/typography/_typography.scss
+++ b/sass/elements/typography/_typography.scss
@@ -1,7 +1,9 @@
+@use "sass:math";
+
 // Default form checkbox Properties
 $default-component-typography-properties:(
     "HeadingColor": getThemeProperty(textColorDark),
-    "HeadingMargin": 0 0 calc(getThemeProperty(layoutSpace) / 2) 0
+    "HeadingMargin": 0 0 math.div(getThemeProperty(layoutSpace), 2) 0
 );
 // If $component-form-checkbox-properties is set, lets merge into our defaults
 $component-typography-properties: $default-component-typography-properties !default;

--- a/sass/elements/typography/elements/_p.scss
+++ b/sass/elements/typography/elements/_p.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 // Default p Properties
 $default-element-p-properties:(
     color: getThemeProperty(textColorDark),
@@ -8,7 +10,7 @@ $default-element-p-properties:(
         tablet: (1em, 1.4),
         phone: (1em, 1.4)
     ),
-    margin: 0 0 calc(getThemeProperty(layoutSpace) / 2) 0 
+    margin: 0 0 math.div(getThemeProperty(layoutSpace), 2) 0 
 );
 // If $element-p-properties is set, lets merge into our defaults
 $element-p-properties: $default-element-p-properties !default;

--- a/sass/elements/typography/elements/_p.scss
+++ b/sass/elements/typography/elements/_p.scss
@@ -8,7 +8,7 @@ $default-element-p-properties:(
         tablet: (1em, 1.4),
         phone: (1em, 1.4)
     ),
-    margin: 0 0 getThemeProperty(layoutSpace)/2 0 
+    margin: 0 0 calc(getThemeProperty(layoutSpace) / 2) 0 
 );
 // If $element-p-properties is set, lets merge into our defaults
 $element-p-properties: $default-element-p-properties !default;

--- a/sass/variables/_theme.scss
+++ b/sass/variables/_theme.scss
@@ -14,7 +14,7 @@ $default-theme-properties: (
   // Fonts
   fontHeader: "Montserrat",
   fontText: "Roboto",
-  fontIcon: "Font Awesome 5 Pro",
+  fontIcon: "Font Awesome 6 Pro",
 
   // Layout
   layoutSpace: 20px,


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/#/tasks/29214398
https://werkbotstudios.teamwork.com/#/tasks/27611312

### Summary
- Updates sass syntax to be dart-sass friendly
- Updated hamburger module to dart-sass friendly version
- Updated to FontAwesome 6, which is dart-sass friendly

### Testing Steps
- [x] test with this version of the base install https://github.com/werkbot/silverstripe-install/pull/128
- [x] `npm i`
- [x] general site testing, confirm icons, containers, and hamburgers look good
- [x] test grunt, confirm there are no warnings

### Issues/Concerns
- I have this set to merge into "2.1". I intend to cherry-pick this into version 3, but we don't need to wait for that version to be ready before using this. Recent sites that use dart-sass (larche and the base install) can benefit from this now, but older sites still using compass cannot interpret this syntax.
- I added the 2.1 branch to the list of branches to trigger workflows. The commit that added this also [triggered the workflow](https://github.com/werkbot/framewerk/actions/runs/2699858627), and generated [a draft release](https://github.com/werkbot/framewerk/releases/tag/untagged-b7bf7d1dd88f494fa650). This is labeled as "2.0.8" now, but when this PR is merged with the "minor" tag, we should expect to see that automatically updated to "2.1".