### PR TITLE
bugfix - Button Border

### DIFF
--- a/sass/components/button/_button.scss
+++ b/sass/components/button/_button.scss
@@ -11,6 +11,7 @@ $default-component-button-properties:(
   textHoverColor: getThemeProperty(textColorDark),
   padding: 10px 40px,
   margin: 5px 0,
+  border: none,
   borderRadius: 5px,
   textTransform: initial,
   fontWeight: 400,
@@ -43,7 +44,7 @@ $component-button-properties: $default-component-button-properties !default;
   text-decoration: none;
   padding: getThemeProperty(padding, $component-button-properties);
   margin: getThemeProperty(margin, $component-button-properties);
-  border: none;
+  border: getThemeProperty(border, $component-button-properties);;
   cursor: pointer;
   text-transform: getThemeProperty(textTransform, $component-button-properties);
   font-weight: getThemeProperty(fontWeight, $component-button-properties);


### PR DESCRIPTION
### Summary
> Fixed issue where a buttons default border setting could not be changed.

### Testing Steps
- [ ] Confirm you can set the border of a button component:
```
$component-button-properties: (
  ...
  border: solid 1px map-get($theme-properties, primaryColor),
  ...
);
```

### Issues/Concerns
- I think I have the labels right for this, but please let me know other wise
