### PR TITLE
bugfix - email fields being shrunk

### DIFF
--- a/js/form.js
+++ b/js/form.js
@@ -111,7 +111,6 @@ window.addEventListener('load', function(){
       || inputElement.type == 'datetime-local'
       || inputElement.type == 'week'
       || inputElement.type == 'month'
-      || inputElement.type == 'email'
       || inputElement.type == 'password'
     ){
       shrinkLabel(inputElement);


### PR DESCRIPTION
### Ticket Link
https://werkbotstudios.teamwork.com/#/tasks/29371998

### Summary
> Removed email field's label from being shrunk by default

### Testing Steps
- [ ] Test an email field, confirm the label is not shrunk by default

### Issues/Concerns
- I assume this was for email fields that had a placeholder, but isn't necessary since we have a separate check in place for this
