### PR TITLE
Read last tag on branch and pass as input to draft release so it can calculate the next release

### DIFF
--- a/.github/workflows/draftrelease.yml
+++ b/.github/workflows/draftrelease.yml
@@ -17,14 +17,25 @@ jobs:
     outputs:
       output: ${{ steps.update_release_draft.outputs.tag_name }}
     steps:
-      - name: Draft Release
-        id: update_release_draft
-        uses: release-drafter/release-drafter@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Checkout
         uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+
+      # Get the last tag created on this branch
+      - name: Get Last Tag
+        id: last_tag
+        run: |
+          LASTTAG=$(git describe --tags | sed -re "s/-.+//")
+          echo "::set-output name=last_tag_on_branch::$LASTTAG"
+
+      - name: Draft Release
+        id: update_release_draft
+        uses: tiller1010/release-drafter@master
+        with:
+          last_tag: ${{ steps.last_tag.outputs.last_tag_on_branch }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Get the current package.json version number
       - name: Compare Versions


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/#/tasks/29432669

### Summary
- Updates checkout step to include tags
- Added step to get the latest tag on the current branch
- Passed last tag as input to release drafter so it can calculate the next release based on PR labels

### Testing Steps
- [x] fork this repo and enable actions
- [x] if you have an existing fork, add "2.0" and "2.1" branches from this repo (this can be done within Github, under "New Branch")
- [x] commit to "2.0" or make PRs and merge them in
- [ ] monitor the action under the actions tab, confirm the last tag is detected as 2.0.something
- [ ] confirm the draft release is generated with an accurate tag
- [ ] repeat the same steps for "2.1" to confirm the last tag is detected as 2.1.something

### Issues/Concerns
- Your fork's tags may differ from this repo.
- I had to fork the action repo to add this new input. There is an existing "tag" input, but this is an override for the generated tag. https://github.com/tiller1010/release-drafter/commit/dbc8ee199d00b4952bfbcfca09bc4f77896d1e0c
- Two draft releases cannot exist at once with this action. I had a 2.0.x release in draft mode, but it was replaced with a 2.1.x draft when I made changes to 2.1.