### PR TITLE
Master into 2.0

### DIFF
--- a/.github/workflows/draftrelease.yml
+++ b/.github/workflows/draftrelease.yml
@@ -17,14 +17,25 @@ jobs:
     outputs:
       output: ${{ steps.update_release_draft.outputs.tag_name }}
     steps:
-      - name: Draft Release
-        id: update_release_draft
-        uses: release-drafter/release-drafter@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Checkout
         uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+
+      # Get the last tag created on this branch
+      - name: Get Last Tag
+        id: last_tag
+        run: |
+          LASTTAG=$(git describe --tags | sed -re "s/-.+//")
+          echo "::set-output name=last_tag_on_branch::$LASTTAG"
+
+      - name: Draft Release
+        id: update_release_draft
+        uses: tiller1010/release-drafter@master
+        with:
+          last_tag: ${{ steps.last_tag.outputs.last_tag_on_branch }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Get the current package.json version number
       - name: Compare Versions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "werkbot-framewerk",
-  "version": "2.1.2",
+  "version": "2.0.7",
   "description": "A framework of css and javascript that Werkbot uses as a foundation to build our websites.",
   "main": "js/form.js",
   "directories": {


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/#/tasks/29432669

### Summary
- Cherry picked branch accurate tags commit from master
- Set package.json version to the last 2.0.x release, 2.0.7 (which will be incremented to 2.0.8 automatically when this is merged)

### Testing Steps
- [ ] confirm this looks good and makes sense

### Concern
- We'll just have to monitor the action behavior after merging this. There's not a totally accurate way of testing this besides making a fork that is near identical in tags and branches.