### PR TITLE
Replaced fontawesome with free version (#47)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@fortawesome/fontawesome-free": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.1.2.tgz",
+      "integrity": "sha512-XwWADtfdSN73/udaFm+1mnGIj/ShDZNFMe/PRoqv3FhQ4GNI2PUN70yFTPsjq65Lw2C9i4TG5/hTbxXIXVCiqQ=="
+    },
     "hamburgers": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/hamburgers/-/hamburgers-1.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   "homepage": "https://github.com/werkbot/framewerk#readme",
   "dependencies": {
     "hamburgers": "^1.2",
-    "@fortawesome/fontawesome-pro": "^6"
+    "@fortawesome/fontawesome-free": "^6"
   }
 }

--- a/sass/variables/_theme.scss
+++ b/sass/variables/_theme.scss
@@ -14,7 +14,7 @@ $default-theme-properties: (
   // Fonts
   fontHeader: "Montserrat",
   fontText: "Roboto",
-  fontIcon: "Font Awesome 6 Pro",
+  fontIcon: "Font Awesome 6 Free",
 
   // Layout
   layoutSpace: 20px,


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/#/tasks/29451212

### Concern
- This isn't much of an issue in 2.0, as fontawesome is not included at all there. It does still define the `fontIcon` as the pro version though.