### PR TITLE
Fix publish action

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,7 +5,7 @@ name: Node.js Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   publish-npm:
@@ -17,6 +17,18 @@ jobs:
           node-version: 16
           registry-url: https://registry.npmjs.org/
       - run: npm ci
-      - run: npm publish
+
+      # Get the lastest version on npm and the version currently being published and convert both into valid decimals (we can ignore the patch numbers)
+      # If the latest version is greater than the current version, then we need to pass in a dist-tag (prevents overwrite of the latest version)
+      # https://docs.npmjs.com/adding-dist-tags-to-packages
+      - name: Compare lastest npm version and publish
+        run: |
+          LATEST=$(npm show werkbot-framewerk version | sed -re "s/\.[0-9]+$//")
+          CURRENT=$(npm version | grep werkbot-framewerk | sed -re "s/[a-z]*//g;s/[-|,|:|']//g;s/\s//g;s/\.[0-9]+$//")
+          if (( $(echo "$LATEST > $CURRENT" | bc -l) )); then
+            npm publish --tag support
+          else
+            npm publish
+          fi
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/#/tasks/29506709

### Summary
- Changed the event trigger for this action to "published". This will work for draft releases when they are published.
- Added shell script to publish step to determine if we need a "support" dist-tag. This will prevent overwrites of the latest version.

### Testing Steps
- [x] create a fork
- [x] update your workflow file to echo something instead of `npm publish`
```
LATEST=$(npm show werkbot-framewerk version | sed -re "s/\.[0-9]+$//")
CURRENT=$(npm version | grep werkbot-framewerk | sed -re "s/[a-z]*//g;s/[-|,|:|']//g;s/\s//g;s/\.[0-9]+$//")
if (( $(echo "$LATEST > $CURRENT" | bc -l) )); then
  echo "support"
else
  echo "latest"
fi
```
- [ ] publish a release on 2.0, confirm "support" is echoed (check your actions tab)
- [ ] publish a release on 2.1, confirm "latest" is echoed

### Issues/Concerns
- There isn't a great way to test the `npm publish` step here.
