### PR TITLE
fix: added missing text-justify class

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,5 +14,5 @@
 ### Git Flow
 - **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
 - "Squash and merge" is good on "feature/\*" into "develop"
-- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "master"
+- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "main"
 - With npm repositories, the version number **must** be incremented manually, before merging the release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "werkbot-framewerk",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "description": "A framework of css and javascript that Werkbot uses as a foundation to build our websites.",
   "main": "js/form.js",
   "directories": {

--- a/sass/elements/typography/defaults/_text.scss
+++ b/sass/elements/typography/defaults/_text.scss
@@ -41,6 +41,9 @@ sup {
 .text-right{
     @include importantOptionFor(text-align, right);
 }
+.text-justify{
+    @include importantOptionFor(text-align, justify);
+}
 .large-text{
     @include importantOptionFor(font-size, getThemeProperty(largeTextFontSize, $element-text-properties));
 }


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/app/tasks/33336887

### Summary
Added missing text-justify class

### Testing Steps
- [ ] build into a site
- [ ] confirm the text-justify class work (most noticeable with headings)

### Git Flow
- **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
- "Squash and merge" is good on "feature/\*" into "develop"
- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "master"
- With npm repositories, the version number **must** be incremented manually, before merging the release.
