### PR TITLE
fix: disabled pointer events on select arrow

### DIFF
--- a/sass/components/form/components/_select.scss
+++ b/sass/components/form/components/_select.scss
@@ -70,6 +70,7 @@ $component-form-select-properties: $default-component-form-select-properties !de
       content: getThemeProperty(icon, $component-form-select-properties);
       font-family: getThemeProperty(iconFontFamily, $component-form-select-properties);
       color: getThemeProperty(iconTextColor, $component-form-select-properties);
+      pointer-events: none;
     }
   }
 }


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/app/tasks/33374233
> See attached "Gallery Filters" – Where the physical arrow is on the drop down menus – you cannot click

### Summary
Disabled pointer events for select field arrows

### Testing Steps
- [x] build into a site
- [x] create a form with select fields
- [x] confirm you can click on the arrow to open the select dropdown

### Git Flow
- **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
- "Squash and merge" is good on "feature/\*" into "develop"
- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "main"
- With npm repositories, the version number **must** be incremented manually, before merging the release.
