### PR TITLE
fix: removed image width 100%

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "werkbot-framewerk",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "description": "A framework of css and javascript that Werkbot uses as a foundation to build our websites.",
   "main": "js/form.js",
   "directories": {

--- a/sass/elements/image/_image.scss
+++ b/sass/elements/image/_image.scss
@@ -2,44 +2,44 @@
   Image
   Generic image classes
   These classes are set from silverstripe html editor
-*/
-$default-element-img-properties:(
-    borderRadius: initial,
-    boxShadow: none
+ */
+$default-element-img-properties: (
+  borderRadius: initial,
+  boxShadow: none
 );
 // If $element-img-properties is set, lets merge into our defaults
 $element-img-properties: $default-element-img-properties !default;
-@if($element-img-properties){
+@if ($element-img-properties) {
   $element-img-properties: recursive-map-merge($default-element-img-properties, $element-img-properties);
 }
-img{
-  &.left{
-  	float: left;
-  	padding-right: getThemeProperty(layoutSpace);
-  	padding-bottom: getThemeProperty(layoutSpace);
-  	max-width: 100%;
+img {
+  &.left {
+    float: left;
+    padding-right: getThemeProperty(layoutSpace);
+    padding-bottom: getThemeProperty(layoutSpace);
+    max-width: 100%;
     height: auto;
   }
-  &.right{
-  	float: right;
-  	padding-left: getThemeProperty(layoutSpace);
-  	padding-bottom: getThemeProperty(layoutSpace);
-  	max-width: 100%;
+  &.right {
+    float: right;
+    padding-left: getThemeProperty(layoutSpace);
+    padding-bottom: getThemeProperty(layoutSpace);
+    max-width: 100%;
     height: auto;
   }
-  &.center{
-  	display: block;
-  	margin: 0 auto;
-  	text-align: center;
-  	padding: getThemeProperty(layoutSpace) 0;
-  	max-width: 100%;
+  &.center {
+    display: block;
+    margin: 0 auto;
+    text-align: center;
+    padding: getThemeProperty(layoutSpace) 0;
+    max-width: 100%;
     height: auto;
   }
-  &.leftAlone{
-  	display: block;
-  	text-align: left;
-  	padding: getThemeProperty(layoutSpace) 0;
-  	max-width: 100%;
+  &.leftAlone {
+    display: block;
+    text-align: left;
+    padding: getThemeProperty(layoutSpace) 0;
+    max-width: 100%;
     height: auto;
   }
 }
@@ -49,24 +49,4 @@ img{
     box-shadow: getThemeProperty(boxShadow, $element-img-properties);
   }
 }
-@media only screen and (max-width: map-get(getThemeProperty(breakpointResponsive), tablet)) {  img{
-    &.left,
-    &.right,
-    &.center,
-    &.leftAlone{
-    	max-width: 100%;
-      height: auto;
-    }
-  }
-}
-@media only screen and (max-width: map-get(getThemeProperty(breakpointResponsive), phone)) {
-  img{
-    &.left,
-    &.right,
-    &.center,
-    &.leftAlone{
-    	width: 100%;
-      height: auto;
-    }
-  }
-}
+


### PR DESCRIPTION
https://werkbotstudios.teamwork.com/app/tasks/34289913

### Summary
Removed the width 100% rules for images

### Testing Steps
- [x] confirm images are not forced to 100% width if they use a left/right/center/etc.. class

### Issues/Concerns
- Looks like the rules were added in this PR, I don't see a reason to keep them https://github.com/werkbot/framewerk/pull/7

### Git Flow
- **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
- "Squash and merge" is good on "feature/\*" into "develop"
- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "main"
- With npm repositories, the version number **must** be incremented manually, before merging the release.
