### PR TITLE
Added line-height to button properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "werkbot-framewerk",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "description": "A framework of css and javascript that Werkbot uses as a foundation to build our websites.",
   "main": "js/form.js",
   "directories": {

--- a/sass/components/button/_button.scss
+++ b/sass/components/button/_button.scss
@@ -20,6 +20,7 @@ $default-component-button-properties:(
   textAlign: center,
   disabledColor: #dddddd,
   disabledTextColor: getThemeProperty(textColorLight),
+  lineHeight: 1,
   variants: (
     white-btn: (
       background-color: getThemeProperty(backgroundColorLight),
@@ -53,6 +54,7 @@ $component-button-properties: $default-component-button-properties !default;
   font-weight: getThemeProperty(fontWeight, $component-button-properties);
   font-family: getThemeProperty(fontFamily, $component-button-properties);
   font-size: getThemeProperty(fontSize, $component-button-properties);
+  line-height: getThemeProperty(lineHeight, $component-button-properties);
   text-align: getThemeProperty(textAlign, $component-button-properties);
   -webkit-appearance: none;
   -webkit-transition: background-color 0.25s ease-out;

--- a/sass/components/button/_button.scss
+++ b/sass/components/button/_button.scss
@@ -20,7 +20,7 @@ $default-component-button-properties:(
   textAlign: center,
   disabledColor: #dddddd,
   disabledTextColor: getThemeProperty(textColorLight),
-  lineHeight: 1,
+  lineHeight: inherit,
   variants: (
     white-btn: (
       background-color: getThemeProperty(backgroundColorLight),


### PR DESCRIPTION
### Summary
> Added line-height to button properties

### Testing Steps
- [ ] Test with any site, confirm the button has a line-height of 1
- [ ] Confirm you can set the line height through properties

### Issues/Concerns
- This issue came up with Otto QA, the line height set on the paragraph tag of 1.65 was adding to the vertical padding
- An alternative would be to attempt offset the vertical padding, but is difficult to calculate
- Another alternative would be to set the line height to inherit and set the line height locally where needed
- All in all, let me know what you think

### Git Flow
- **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
- "Squash and merge" is good on "feature/\*" into "develop"
- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "main"
- With npm repositories, the version number **must** be incremented manually, before merging the release.
