### PR TITLE
Added desktop directions (right to left, left to right, top to bottom, bottom to top)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "werkbot-framewerk",
-  "version": "2.1.13",
+  "version": "2.1.14",
   "description": "A framework of css and javascript that Werkbot uses as a foundation to build our websites.",
   "main": "js/form.js",
   "directories": {

--- a/sass/base/layout/_layout.scss
+++ b/sass/base/layout/_layout.scss
@@ -46,6 +46,21 @@
     .#{$label}-show{
       display: inherit;
     }
+    /* Flex Container Direction */
+    .flex-container{
+      &.#{$label}-ltr{
+        flex-direction: row;
+      }
+      &.#{$label}-rtl{
+        flex-direction: row-reverse;
+      }
+      &.#{$label}-ttb{
+        flex-direction: column;
+      }
+      &.#{$label}-btt{
+        flex-direction: column-reverse;
+      }
+    }
   }
 }
 /*

--- a/sass/base/layout/_layout.scss
+++ b/sass/base/layout/_layout.scss
@@ -22,6 +22,21 @@
 .desktop-show{
   display: inherit;
 }
+/* Flex Container Direction */
+.flex-container{
+  &.desktop-ltr{
+    flex-direction: row;
+  }
+  &.desktop-rtl{
+    flex-direction: row-reverse;
+  }
+  &.desktop-ttb{
+    flex-direction: column;
+  }
+  &.desktop-btt{
+    flex-direction: column-reverse;
+  }
+}
 /*
   DESKTOP BREAKPOINTS
   Loop through each desktop defined breakpoint


### PR DESCRIPTION
### Summary
> Added desktop directions (right to left, left to right, top to bottom, bottom to top)

### Testing Steps
- [ ] Test with any site
- [ ] On a container (If a newer site) test the Layout -> Direction settings, confirm these work for Desktop

### Issues/Concerns
- This originally came up when updating flexcut, their "cart" page uses a direction class (The side bar should appear on the right side, not the left)

### Git Flow
- **DO NOT** delete "release/\*" or "hotfix/\*" branches after merging a PR. These are used to publish the next release, and they are deleted automatically.
- "Squash and merge" is good on "feature/\*" into "develop"
- "Create a merge commit" is good on "release/\*" or "hotfix/\*" into "main"
- With npm repositories, the version number **must** be incremented manually, before merging the release.
